### PR TITLE
lint_result may contains nil

### DIFF
--- a/lib/eslint/plugin.rb
+++ b/lib/eslint/plugin.rb
@@ -34,7 +34,7 @@ module Danger
     #
     def lint
       lint_results
-        .reject { |r| r['messages'].length.zero? }
+        .reject { |r| r.nil? || r['messages'].length.zero? }
         .reject { |r| r['messages'].first['message'].include? 'matching ignore pattern' }
         .map { |r| send_comment r }
     end


### PR DESCRIPTION
`lint_result` sometimes contained `nil`.
Fix to remove `nil` in `reject`.