### PR TITLE
Fix rubocop fail

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
I found a case of rubocop fail by warnings about [immutable string literal](https://bugs.ruby-lang.org/issues/11473) that is a feature of upcomming ruby ver.3.

I fixed it by add following block to `.rubocop.yml`

```yml
Style/FrozenStringLiteralComment:
  Enabled: false
```

### version

- ruby: v2.3.1
- rubocop: v0.57.2

### log

```sh
$ bundle exec rake spec
```

```
.........

Finished in 0.14599 seconds (files took 0.70687 seconds to load)
9 examples, 0 failures

Running RuboCop...
Inspecting 6 files
CCCCCC

Offenses:

lib/danger_eslint.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
require 'eslint/gem_version'
^
lib/danger_plugin.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
require 'eslint/plugin'
^
lib/eslint/gem_version.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
module Eslint
^
lib/eslint/plugin.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
require 'mkmf'
^
spec/eslint_spec.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
require File.expand_path('spec_helper', __dir__)
^
spec/spec_helper.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
require 'pathname'
^

6 files inspected, 6 offenses detected
RuboCop failed!
```