### PR TITLE
Account for renamed files when linting

### DIFF
--- a/lib/eslint/plugin.rb
+++ b/lib/eslint/plugin.rb
@@ -71,10 +71,18 @@ module Danger
       bin = eslint_path
       raise 'eslint is not installed' unless bin
       return run_lint(bin, '.') unless filtering
-      ((git.modified_files - git.deleted_files) + git.added_files)
+      lint_files
         .select { |f| target_extensions.include?(File.extname(f)) }
         .map { |f| f.gsub("#{Dir.pwd}/", '') }
         .map { |f| run_lint(bin, f).first }
+    end
+
+    # Filtered files for linting
+    #
+    # return [String]
+    def lint_files
+      ((git.modified_files - git.deleted_files - git.renamed_files.map { |f| f[:before] }) +
+       (git.added_files + git.renamed_files.map { |f| f[:after] }))
     end
 
     # Run eslint aginst a single file.


### PR DESCRIPTION
When a file is renamed, the old path will show up in `git.modified_files` and will cause eslint to fail since it cannot find the file. To account for this, remove the old path and only lint the new.