### PR TITLE
Add support for renamed files

### DIFF
--- a/lib/eslint/plugin.rb
+++ b/lib/eslint/plugin.rb
@@ -71,7 +71,7 @@ module Danger
       bin = eslint_path
       raise 'eslint is not installed' unless bin
       return run_lint(bin, '.') unless filtering
-      ((git.modified_files - git.deleted_files) + git.added_files)
+      ((git.modified_files - git.deleted_files - git.renamed_files.map { |r| r[:before] }) + git.added_files + git.renamed_files.map { |r| r[:after] })
         .select { |f| target_extensions.include?(File.extname(f)) }
         .map { |f| f.gsub("#{Dir.pwd}/", '') }
         .map { |f| run_lint(bin, f).first }


### PR DESCRIPTION
Fixes the following error when running `eslint.lint` with following setup on a PR that contains renamed files.

Setup:

```
eslint.bin_path = "./node_modules/eslint/bin/eslint.js"
eslint.config_file = ".eslintrc.js"
eslint.filtering = true
eslint.ignore_file = ".eslintignore"
eslint.target_extensions += %W(.js, .jsx, .ts .tsx)
eslint.lint
```

Error:

```
Traceback (most recent call last):
	29: from /usr/local/bin/bundle:23:in `<main>'
	28: from /usr/local/bin/bundle:23:in `load'
	27: from /Users/foobar/.gem/gems/bundler-2.2.5/exe/bundle:37:in `<top (required)>'
	26: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	25: from /Users/foobar/.gem/gems/bundler-2.2.5/exe/bundle:49:in `block in <top (required)>'
	24: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli.rb:24:in `start'
	23: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	22: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli.rb:30:in `dispatch'
	21: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	20: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	19: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	18: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli.rb:494:in `exec'
	17: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli/exec.rb:28:in `run'
	16: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli/exec.rb:63:in `kernel_load'
	15: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli/exec.rb:63:in `load'
	14: from /Users/foobar/.gem/bin/danger:23:in `<top (required)>'
	13: from /Users/foobar/.gem/bin/danger:23:in `load'
	12: from /Users/foobar/.gem/gems/danger-8.2.2/bin/danger:5:in `<top (required)>'
	11: from /Users/foobar/.gem/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
	10: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/commands/pr.rb:63:in `run'
	 9: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/commands/local_helpers/local_setup.rb:43:in `setup'
	 8: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/commands/pr.rb:64:in `block in run'
	 7: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:287:in `run'
	 6: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:201:in `parse'
	 5: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:201:in `instance_eval'
	 4: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:204:in `block in parse'
	 3: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:311:in `eval_file'
	 2: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:311:in `eval'
	 1: from danger/DangerfilePreChecks:46:in `eval_file'
/Users/foobar/.gem/gems/danger-eslint-0.1.5/lib/eslint/plugin.rb:51:in `lint': wrong number of arguments (given 1, expected 0) (ArgumentError)
	29: from /usr/local/bin/bundle:23:in `<main>'
	28: from /usr/local/bin/bundle:23:in `load'
	27: from /Users/foobar/.gem/gems/bundler-2.2.5/exe/bundle:37:in `<top (required)>'
	26: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	25: from /Users/foobar/.gem/gems/bundler-2.2.5/exe/bundle:49:in `block in <top (required)>'
	24: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli.rb:24:in `start'
	23: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	22: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli.rb:30:in `dispatch'
	21: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	20: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	19: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	18: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli.rb:494:in `exec'
	17: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli/exec.rb:28:in `run'
	16: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli/exec.rb:63:in `kernel_load'
	15: from /Users/foobar/.gem/gems/bundler-2.2.5/lib/bundler/cli/exec.rb:63:in `load'
	14: from /Users/foobar/.gem/bin/danger:23:in `<top (required)>'
	13: from /Users/foobar/.gem/bin/danger:23:in `load'
	12: from /Users/foobar/.gem/gems/danger-8.2.2/bin/danger:5:in `<top (required)>'
	11: from /Users/foobar/.gem/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
	10: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/commands/pr.rb:63:in `run'
	 9: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/commands/local_helpers/local_setup.rb:43:in `setup'
	 8: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/commands/pr.rb:64:in `block in run'
	 7: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:287:in `run'
	 6: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:201:in `parse'
	 5: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:201:in `instance_eval'
	 4: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:204:in `block in parse'
	 3: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:311:in `eval_file'
	 2: from /Users/foobar/.gem/gems/danger-8.2.2/lib/danger/danger_core/dangerfile.rb:311:in `eval'
	 1: from danger/DangerfilePreChecks:46:in `eval_file'
/Users/foobar/.gem/gems/danger-eslint-0.1.5/lib/eslint/plugin.rb:51:in `lint':  (Danger::DSLError)
```

The error arises from the fact that `eslint` is run on a file that has been renamed and thus does not exist and produces output like the following:

```
Oops! Something went wrong! :(

ESLint: 7.20.0

No files matching the pattern "some/path/before/renaming.tsx" were found.
Please check for typing mistakes in the pattern.
```